### PR TITLE
Remove incorrect use of the term "library"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # arduino-i2c-slave
-Arduino I2C library for receiving LimitOS messages with the Arduino as a slave
+Arduino I2C sketch for receiving LimitOS messages with the Arduino as a slave
 
 Please see https://github.com/llawlor/LimitOS for the full source code of LimitOS, where this script will be dynamically generated.


### PR DESCRIPTION
This is a sketch, not a library, so it's incorrect to call it a "library".

This error also occurs in the repository description. That can not be fixed via a pull request but it's easily done by clicking the **Edit** button to the right of the description text shown at the top of the repository's home page:
https://github.com/llawlor/arduino-i2c-slave
